### PR TITLE
[COSMOS] Update chain in network params

### DIFF
--- a/core/src/wallet/cosmos/cosmosNetworks.cpp
+++ b/core/src/wallet/cosmos/cosmosNetworks.cpp
@@ -43,7 +43,7 @@ namespace ledger {
                             {0x04, 0x88, 0xB2, 0x1E},
                             {0xEB, 0x5A, 0xE9, 0x87},
                             {},
-                            "cosmoshub-2",
+                            "cosmoshub-3",
                             {}
                     );
                     return COSMOS;

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * RIppleLikeTransactionDatabaseHelper
+ * CosmosLikeTransactionDatabaseHelper
  *
  * Created by El Khalil Bellakrid on 06/01/2019.
  *

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.h
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.h
@@ -1,6 +1,6 @@
 /*
  *
- * RIppleLikeTransactionDatabaseHelper
+ * CosmosLikeTransactionDatabaseHelper
  *
  * Created by El Khalil Bellakrid on 06/01/2019.
  *


### PR DESCRIPTION
Looking at [this upgrade guide](https://medium.com/@meleacrypto/cosmos-3-hub-upgrade-guide-4d6791a12bdc)
from a validator, it looks like the only difference in the protocol is
the number of validators (from 100 to 125)


----